### PR TITLE
Explicitly call out client initiation as a property.

### DIFF
--- a/documents/charter.md
+++ b/documents/charter.md
@@ -11,5 +11,5 @@ The properies of this mechanism are as follows:
 1. On-path establishment. That is, no off-path element is needed to establish the communication channel between the entity communicating the properies and the client.
 2. Security. The mechanism must ensure the confidentiality, integrity, and authenticity of the communication. The mechanism must have independent security context from the application's security context. The group must not define new security mechanisms for this purpose.
 3. Associativity with an application. The network properties must be associated with a given application traversing the network, for example a video playback.
-4. Client initiatiion. The communication channel is initiated by a client device, just as the end to end application flows are also typically iniated by a client.
+4. Client initiatiion. The communication channel is initiated by a client device, just as the end to end application flows are also typically initiated by a client.
 5. Scalability. The mechanism must be scalable and implementable by Internet infrastructure as it exists today, for example mobile network packet cores.

--- a/documents/charter.md
+++ b/documents/charter.md
@@ -11,4 +11,5 @@ The properies of this mechanism are as follows:
 1. On-path establishment. That is, no off-path element is needed to establish the communication channel between the entity communicating the properies and the client.
 2. Security. The mechanism must ensure the confidentiality, integrity, and authenticity of the communication. The mechanism must have independent security context from the application's security context. The group must not define new security mechanisms for this purpose.
 3. Associativity with an application. The network properties must be associated with a given application traversing the network, for example a video playback.
-4. Scalability. The mechanism must be scalable and implementable by Internet infrastructure as it exists today, for example mobile network packet cores.
+4. Client initiatiion. The communication channel is initiated by a client device, just as the end to end application flows are also typically iniated by a client.
+5. Scalability. The mechanism must be scalable and implementable by Internet infrastructure as it exists today, for example mobile network packet cores.


### PR DESCRIPTION
This addresses #6 by explicitly stating that the communication channel should be client initiated.

This is a nice property to have and is not overly onerous on applications, or limiting use-cases.