### PR TITLE
Avoid claiming that we will signal receipt and conformance

### DIFF
--- a/documents/charter.md
+++ b/documents/charter.md
@@ -34,7 +34,7 @@ limits for both upstream and downstream traffic.
 2. Allow network elements to update the application limit as needed.
 
 3. If deemed necessary, a client conformance signaling mechanism to allow clients
-to signal their receipt of application limits and ability to conform to them.
+to signal their ability to receive application limits and/or conform to them.
 
 The application limit serves as a guideline to enhance user experience
 and represents the maximum bitrate manageable by a single network


### PR DESCRIPTION
From discussion on list, i think:

- no one has asked for a mechanism to signal that the advertised application limit was actually received ("signal their receipt")

- some folks think it might be useful for an endpoint to signal to the network that they are *capable* of receiving application limits.

- there is very little consensus around what it would even mean to signal intent to conform to the limits, especially if the limits aren't even known at the time of signalling.

So this change to the charter tries to avoid opting into things that no one has asked for, or coupling things together when only one of them might be meaningful or necessary.