### PR TITLE
Remove "conformance" language, clean up open issues.

### DIFF
--- a/documents/charter.md
+++ b/documents/charter.md
@@ -17,12 +17,11 @@ the path of a UDP 5-tuple that is capable of dropping or delaying packets.
 
 ## Open Issues for Investigation
 
-The working group will investigate and determine the necessity of a "client
-conformance signaling" mechanism, that allows clients to signal their receipt
-of the application limits and ability to conform to them. This investigation
-will also assess the impact to user privacy. This investigation will inform
-the decision on whether to include such a mechanism in the protocol.
-
+The working group will determine the necessity of a client signaling mechanism
+which; (1) signals their capability of receiving application limits, and (2)
+signals their receipt of application limits. The working group will also
+determine the mechanism’s impact on user privacy. These investigations will
+inform the decisions on whether to include such mechanisms in the protocol.
 
 ## Goals
 
@@ -32,9 +31,6 @@ This work will define a way for an application to:
 limits for both upstream and downstream traffic.
 
 2. Allow network elements to update the application limit as needed.
-
-3. If deemed necessary, a client conformance signaling mechanism to allow clients
-to signal their receipt of application limits and ability to conform to them.
 
 The application limit serves as a guideline to enhance user experience
 and represents the maximum bitrate manageable by a single network

--- a/documents/charter.md
+++ b/documents/charter.md
@@ -18,8 +18,8 @@ the path of a UDP 5-tuple that is capable of dropping or delaying packets.
 ## Open Issues for Investigation
 
 The working group will determine the necessity of a client signaling mechanism
-which; (1) signals their capability of receiving application limits, and (2)
-signals their receipt of application limits. The working group will also
+which might separately signal their capability of receiving application limits
+and their receipt of application limits. The working group will also
 determine the mechanism’s impact on user privacy. These investigations will
 inform the decisions on whether to include such mechanisms in the protocol.
 


### PR DESCRIPTION
This is an alternative to #107. 

Our thinking is that the "conformance" language is superfluous. The core issue that people have highlighted is that there is a potential need for clients to signal that they can receive the limits, and also that they _have_ received them. 

The former requirement is borne out of the fact that in order for a network element to send such signals it is useful to know the client can receive them and there will not be problems.

The latter is more of an acknowledgment mechanism, rather than a "I will abide" mechanism, hence "conformance" is the wrong word. There is a general sense that signaling "conformance" is immaterial to the network's decision making, as some degree of "trust-but-verify"

This PR attempts to resolve this by rewording the open issues section to explicitly call out these two determinations. It also removes the goal referencing them so as to not confuse the matter, as calling it out as an open issue is sufficient to provide the WG scope to work on this problem.