### PR TITLE
Change "application limits" to "throughput advice"

### DIFF
--- a/documents/charter.md
+++ b/documents/charter.md
@@ -7,19 +7,19 @@ influence these applications. However, when networks enforce
 rate-limiters, applications like video streaming or conferencing
 struggle to adapt, leading to a suboptimal user experience.
 
-This WG aims to establish a mechanism for network devices intending to
+This WG aims to establish a mechanism for network elements intending to
 rate-limit a UDP 5-tuple to communicate an upper bound on achievable
-bitrate termed "application limit"—to the endpoint originating the UDP
+bitrate termed "throughput advice" — to the endpoint originating the UDP
 5-tuple. 
 
-In the context of this charter, a "network device" is defined as anything on 
+In the context of this charter, a "network element" is defined as anything on 
 the path of a UDP 5-tuple that is capable of dropping or delaying packets.
 
 ## Open Issues for Investigation
 
 The working group will determine the necessity of a client signaling mechanism
-which might separately signal their capability of receiving application limits
-and their receipt of application limits. The working group will also
+which might separately signal their capability of receiving throughput advice
+and their receipt of throughput advice. The working group will also
 determine the mechanism’s impact on user privacy. These investigations will
 inform the decisions on whether to include such mechanisms in the protocol.
 
@@ -27,20 +27,20 @@ inform the decisions on whether to include such mechanisms in the protocol.
 
 This work will define a way for an application to:
 
-1. Receive notifications from network elements about the application
-limits for both upstream and downstream traffic.
+1. Receive notifications from network elements about the throughput
+advice for both upstream and downstream traffic.
 
-2. Allow network elements to update the application limit as needed.
+2. Allow network elements to update the throughput advice as needed.
 
-The application limit serves as a guideline to enhance user experience
+The throughput advice serves as a guideline to enhance user experience
 and represents the maximum bitrate manageable by a single network
-element. It is not an indicator of network congestion. This mechanism
-focuses on bitrate limits intended for adaptive bitrate applications and
-operates independently of congestion control algorithms and mechanisms
+element. It is not a strict indicator of network congestion. This mechanism
+focuses on bitrate advice intended for adaptive bitrate applications and
+is not a replacement for congestion control algorithms and mechanisms
 like BBR, ECN, and L4S.
 
 The working group will analyze the privacy and security implications of
-the solution.
+the mechanism.
 
 ### Non-Goals
 
@@ -50,7 +50,7 @@ This working group will not produce a solution that:
 
 2. Is appropriate for use as input to a congestion control algorithm
 
-3. Provides information other than the application limit 
+3. Provides information other than the throughput advice 
 
 
 ## Program of Work
@@ -58,7 +58,7 @@ This working group will not produce a solution that:
 The WG is expected to:
 
 1. Develop a standards track protocol to communicate an upper bound on
-achievable bitrate —termed "application limit"— to the endpoint.
+achievable bitrate — termed "throughput advice"— to the endpoint.
 2. Develop an Informational Applicability and Manageability specification.
 
 The WG will work collaboratively with the WEBTRANS, MOQ, AVTCORE, MOPS,


### PR DESCRIPTION
This attempts to address #106 where "throughput advice" seems to be in favor. Also make some small editorial changes to clarify that this is not a _replacement_ for congestion control.