### PR TITLE
Off-path is a non goal

### DIFF
--- a/documents/charter.md
+++ b/documents/charter.md
@@ -50,7 +50,9 @@ This working group will not produce a solution that:
 
 2. Is appropriate for use as input to a congestion control algorithm
 
-3. Provides information other than the throughput advice 
+3. Provides information other than the throughput advice
+
+4. Signals throughput advice using off-path interfaces.
 
 
 ## Program of Work


### PR DESCRIPTION
While the charter defines a network element as something on-path it is only implicitly understood that the solution space is restricted to on-path signaling. This PR aims to make off-path signaling explicitly out of scope. 