### PR TITLE
 defining the "network element" inline to provide the definition ahead of using it, uses throughput advice instead of bitrate

### DIFF
--- a/documents/charter.md
+++ b/documents/charter.md
@@ -14,13 +14,14 @@ rate-limit a UDP 5-tuple to communicate an upper bound on achievable
 bitrate termed "throughput advice" — to the endpoint originating the UDP
 5-tuple. 
 
-This mechanism will allow an application to receive notifications from network elements containing throughput
+This mechanism will allow an application to receive notifications from network elements, a "network element" is defined as anything on 
+the path of a UDP 5-tuple that is capable of dropping or delaying packets, containing throughput
 advice for both upstream and downstream traffic.
 
 The throughput advice serves as a guideline to enhance user experience
 and represents the maximum bitrate manageable by a single network
 element. It is not a strict indicator of network congestion. This mechanism
-focuses on bitrate advice intended for adaptive bitrate applications and
+focuses on throughput advice intended for adaptive bitrate applications and
 is not a replacement for congestion control algorithms and mechanisms
 like BBR, ECN, and L4S.
 
@@ -30,9 +31,6 @@ The working group will analyze the privacy and security implications of
 the mechanism.
 
 In order to achieve the goals listed above, the working group will determine whether it is necessary for an endpoint to explicitly signal its capability of receiving throughput advice, and whether it is necessary for an endpoint to confirm its receipt of throughput advice.
-
-In the context of this charter, a "network element" is defined as anything on 
-the path of a UDP 5-tuple that is capable of dropping or delaying packets.
 
 ### Non-Goals
 
@@ -49,7 +47,7 @@ This working group will not produce a solution that:
 The WG is expected to:
 
 1. Develop a standards track protocol to communicate an upper bound on
-achievable bitrate — termed "throughput advice"— to the endpoint.
+achievable bitrate — termed "throughput advice"— from network elements to the endpoint.
 2. Develop an Informational Applicability and Manageability specification.
 
 The WG will work collaboratively with the WEBTRANS, MOQ, AVTCORE, MOPS,


### PR DESCRIPTION


Editorial proposal